### PR TITLE
Fix bugs in the Sweden focus tree

### DIFF
--- a/common/ideas/finland.txt
+++ b/common/ideas/finland.txt
@@ -475,7 +475,7 @@ ideas = {
 			picture = HUN_hungarian_monarchy
 			
 			available = {
-				has_country_leader = { id = 15004 ruling_only = yes name = "Väinö II" }
+				has_country_leader = { id = 15004 ruling_only = yes character = FIN_vaino_ii }
 				has_government = neutrality
 			}
 			

--- a/common/ideas/sweden.txt
+++ b/common/ideas/sweden.txt
@@ -303,13 +303,13 @@ ideas = {
 				industrial_capacity_factory = 0.1				
 			}
 			equipment_bonus = {
-				light_tank_equipment = {
+				light_tank_chassis = {
 					build_cost_ic = -0.1 instant = yes
 				}
-				medium_tank_equipment = {
+				medium_tank_chassis = {
 					build_cost_ic = -0.1 instant = yes
 				}
-				heavy_tank_equipment = {
+				heavy_tank_chassis = {
 					build_cost_ic = -0.1 instant = yes
 				}
 			}
@@ -323,13 +323,13 @@ ideas = {
 			}
 			
 			equipment_bonus = {
-				light_tank_equipment = {
+				light_tank_chassis = {
 					build_cost_ic = -0.1 instant = yes
 				}
-				medium_tank_equipment = {
+				medium_tank_chassis = {
 					build_cost_ic = -0.1 instant = yes
 				}
-				heavy_tank_equipment = {
+				heavy_tank_chassis = {
 					build_cost_ic = -0.1 instant = yes
 				}
 			}

--- a/common/ideas/sweden.txt
+++ b/common/ideas/sweden.txt
@@ -344,7 +344,7 @@ ideas = {
 			}
 			
 			modifier = {
-				offence = 0.1
+				army_attack_factor = 0.1
 				army_speed_factor = 0.05
 				special_forces_cap = 0.02
 			}
@@ -358,7 +358,7 @@ ideas = {
 			}
 			
 			modifier = {
-				defence = 0.1
+				army_defence_factor = 0.1
 				max_dig_in = 1
 				attrition = -0.1
 				special_forces_cap = 0.02				
@@ -374,7 +374,7 @@ ideas = {
 			}
 			
 			modifier = {
-				crypto_strength = 1`
+				crypto_strength = 1
 				decryption_power = 25
 			}
 		}

--- a/common/national_focus/Sweden.txt
+++ b/common/national_focus/Sweden.txt
@@ -495,7 +495,7 @@ focus_tree = {
 			}
 			modifier = {
 				factor = 10
-				has_country_leader = { id = 13002 ruling_only = yes name = "Martin Eugen Ekström" }
+				has_country_leader = { id = 13002 ruling_only = yes character = SWE_martin_ekstrom }
 			}
 		}
 		search_filters = { FOCUS_FILTER_ANNEXATION }
@@ -523,6 +523,14 @@ focus_tree = {
 			add_state_claim = 11
 			add_state_claim = 189
 			add_state_claim = 188
+			add_state_claim = 811
+			add_state_claim = 812
+			add_state_claim = 813
+			add_state_claim = 808
+			add_state_claim = 809
+			add_state_claim = 810
+			add_state_claim = 814
+			add_state_claim = 815
 			
 			effect_tooltip = {
 				create_wargoal = {
@@ -540,13 +548,13 @@ focus_tree = {
 			}
 			hidden_effect = {
 				if = {
-					limit = { has_country_leader = { id = 13002 ruling_only = yes name = "Martin Eugen Ekström" } }
+					limit = { has_country_leader = { id = 13002 ruling_only = yes character = SWE_martin_ekstrom } }
 					LIT = { country_event = SCA_sweden.7 }
 					LAT = { country_event = SCA_sweden.7 }
 					EST = { country_event = SCA_sweden.7 }
 				}
 				if = {
-					limit = { NOT = { has_country_leader = { id = 13002 ruling_only = yes name = "Martin Eugen Ekström" } } }
+					limit = { NOT = { has_country_leader = { id = 13002 ruling_only = yes character = SWE_martin_ekstrom } } }
 					create_wargoal = {
 						type = annex_everything
 						target = EST
@@ -997,7 +1005,7 @@ focus_tree = {
 				give_military_access = GER
 				GER = { give_guarantee = SWE }
 			}
-			GER = { country_event = { id = SCA_sweden.37 hours = 2 } }
+			GER = { country_event = { id = SCA_sweden.38 hours = 2 } }
 			custom_effect_tooltip = SWE_permittenttrafiken_tt
 		}
 	}

--- a/common/on_actions/EXP_on_actions.txt
+++ b/common/on_actions/EXP_on_actions.txt
@@ -18,7 +18,7 @@ on_actions = {
 	}
 
 	# country 
-	on_new_term_neutral_election = {
+	on_new_term_election = {
 		random_events = {
 			100 = neutral_election.2
 			100 = neutral_election.3

--- a/common/scripted_triggers/EXP_Elections_scripted_triggers.txt
+++ b/common/scripted_triggers/EXP_Elections_scripted_triggers.txt
@@ -1,0 +1,5 @@
+can_lose_neutrality_support = {
+	communism < 0.18
+	fascism < 0.18
+	neutrality > 0.65
+}

--- a/events/EXP_ElectionEvents.txt
+++ b/events/EXP_ElectionEvents.txt
@@ -205,7 +205,7 @@ country_event = {
 		}
 		add_stability = -0.05
 		add_popularity = {
-			ideology = democratic
+			ideology = neutrality
 			popularity = 0.03
 		}
 		set_country_flag = government_declined_fascists
@@ -288,7 +288,7 @@ country_event = {
 		}
 		add_stability = -0.05
 		add_popularity = {
-			ideology = democratic
+			ideology = neutrality
 			popularity = 0.03
 		}
 		set_country_flag = government_declined_communists
@@ -436,7 +436,7 @@ country_event = {
 		}
 		add_stability = -0.05
 		add_popularity = {
-			ideology = democratic
+			ideology = neutrality
 			popularity = 0.03
 		}
 	}
@@ -511,7 +511,7 @@ country_event = {
 		}
 		add_stability = -0.05
 		add_popularity = {
-			ideology = democratic
+			ideology = neutrality
 			popularity = 0.03
 		}
 	}
@@ -641,7 +641,7 @@ country_event = {
 			}
 		}
 		add_popularity = {
-			ideology = democratic
+			ideology = neutrality
 			popularity = 0.05
 		}
 		remove_ideas_with_trait = motorized_equipment_manufacturer

--- a/events/EXP_ElectionEvents.txt
+++ b/events/EXP_ElectionEvents.txt
@@ -166,6 +166,10 @@ country_event = {
 				tag = USA 
 				date < 1949.1.1
 			} 
+			AND = {
+				tag = GRE
+				#has_dlc = "Battle for the Bosporus"
+			}
 		}
 		OR = { NOT = { tag = SPR } NOT = { date < 1937.1.1 } }
 		has_government = neutrality
@@ -227,6 +231,10 @@ country_event = {
 				tag = USA 
 				date < 1949.1.1
 			} 
+			AND = {
+				tag = GRE
+				#has_dlc = "Battle for the Bosporus"
+			}
 		}
 		OR = { NOT = { tag = SPR } NOT = { date < 1937.1.1 } }
 		has_government = neutrality
@@ -310,6 +318,10 @@ country_event = {
 				tag = USA 
 				date < 1949.1.1
 			} 
+			AND = {
+				tag = GRE
+				#has_dlc = "Battle for the Bosporus"
+			}
 		}
 		OR = { NOT = { tag = SPR } NOT = { date < 1937.1.1 } }
 		has_government = neutrality
@@ -385,6 +397,10 @@ country_event = {
 				tag = USA 
 				date < 1949.1.1
 			} 
+			AND = {
+				tag = GRE
+				#has_dlc = "Battle for the Bosporus"
+			}
 		}
 		OR = { NOT = { tag = SPR } NOT = { date < 1937.1.1 } }
 		has_government = neutrality
@@ -459,6 +475,10 @@ country_event = {
 				tag = USA 
 				date < 1949.1.1
 			} 
+			AND = {
+				tag = GRE
+				#has_dlc = "Battle for the Bosporus"
+			}
 		}
 		OR = { NOT = { tag = SPR } NOT = { date < 1937.1.1 } }
 		has_government = neutrality
@@ -531,6 +551,20 @@ country_event = {
 		has_elections = yes
 		fascism > 0.5
 		is_puppet = no
+		NOT = {
+			AND = {
+				original_tag = SPR
+				has_dlc = "La Resistance"
+			}
+			AND = {
+				original_tag = GRE
+				has_dlc = "Battle for the Bosporus"
+			}
+			AND = {
+				original_tag = TUR
+				has_dlc = "Battle for the Bosporus"
+			}
+		}
 	}
 	
 	option = {	
@@ -570,6 +604,16 @@ country_event = {
 		has_elections = yes
 		communism > 0.5
 		is_puppet = no
+		NOT = {
+			AND = {
+				original_tag = GRE
+				has_dlc = "Battle for the Bosporus"
+			}
+			AND = {
+				original_tag = TUR
+				has_dlc = "Battle for the Bosporus"
+			}
+		}
 	}
 	
 	option = {

--- a/events/EXP_ElectionEvents.txt
+++ b/events/EXP_ElectionEvents.txt
@@ -180,7 +180,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 2
-				can_lose_democracy_support = yes
+				can_lose_neutrality_support = yes
 			}
 			modifier = {
 				add = 1
@@ -241,7 +241,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 2
-				can_lose_democracy_support = yes
+				can_lose_neutrality_support = yes
 			}
 			modifier = {
 				add = 1
@@ -325,7 +325,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 10
-				can_lose_democracy_support = yes
+				can_lose_neutrality_support = yes
 			}
 		}
 		add_popularity = {
@@ -341,7 +341,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 10
-				can_lose_democracy_support = yes
+				can_lose_neutrality_support = yes
 			}
 		}
 		add_popularity = {
@@ -357,7 +357,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 1
-				can_lose_democracy_support = no
+				can_lose_neutrality_support = no
 			}
 		}
 		add_popularity = {
@@ -402,7 +402,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 2
-				can_lose_democracy_support = yes
+				can_lose_neutrality_support = yes
 			}
 			modifier = {
 				add = 1
@@ -476,7 +476,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 2
-				can_lose_democracy_support = yes
+				can_lose_neutrality_support = yes
 			}
 			modifier = {
 				add = 1
@@ -622,7 +622,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 1
-				can_lose_democracy_support = yes
+				can_lose_neutrality_support = yes
 			}
 		}
 		add_popularity = {
@@ -637,7 +637,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 1
-				can_lose_democracy_support = no
+				can_lose_neutrality_support = no
 			}
 		}
 		add_popularity = {
@@ -687,7 +687,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 3
-				can_lose_democracy_support = yes
+				can_lose_neutrality_support = yes
 			}			
 			modifier = {
 				add = 1
@@ -736,7 +736,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 3
-				can_lose_democracy_support = no
+				can_lose_neutrality_support = no
 			}			
 		}
 		name = election.15.a
@@ -750,7 +750,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 10
-				can_lose_democracy_support = yes
+				can_lose_neutrality_support = yes
 			}			
 			modifier = {
 				add = 1

--- a/events/EXP_ElectionEvents.txt
+++ b/events/EXP_ElectionEvents.txt
@@ -295,7 +295,7 @@ country_event = {
 	}
 }
 
-# Democratic Parties in Minority
+# Neutral Parties in Minority
 country_event = {
 	id = neutral_election.6
 	title = election.6.t
@@ -314,7 +314,7 @@ country_event = {
 		OR = { NOT = { tag = SPR } NOT = { date < 1937.1.1 } }
 		has_government = neutrality
 		has_elections = yes
-		democratic < 0.5
+		neutrality < 0.5
 		fascism < 0.5
 		communism < 0.5
 	}
@@ -361,7 +361,7 @@ country_event = {
 			}
 		}
 		add_popularity = {
-			ideology = democratic
+			ideology = neutrality
 			popularity = 0.05
 		}
 		add_political_power = -80

--- a/events/SCA_swedish_events.txt
+++ b/events/SCA_swedish_events.txt
@@ -75,6 +75,7 @@ country_event = {
 		has_country_flag = holiday_cabinet
 		has_government = democratic
 		date > 1936.9.18
+		democratic < 0.5
 	}
 	
 	mean_time_to_happen = {
@@ -138,6 +139,36 @@ country_event = {
 		
 		add_political_power = -100
 		add_popularity = { ideology = neutrality  popularity = -0.1 }
+	}
+}
+
+country_event = {
+	id = SCA_sweden.41
+	title = SCA_sweden.41.t
+	desc = SCA_sweden.41.desc
+	picture = GFX_report_event_election_vote
+
+	fire_only_once = yes
+
+	trigger = {
+		tag = SWE
+		has_country_flag = holiday_cabinet
+		has_government = democratic
+		date > 1936.9.18
+		NOT = { democratic < 0.5 }
+	}
+
+	mean_time_to_happen = {
+		days = 1
+	}
+
+	option = { #Minority Government Wins!
+		name = SCA_sweden.41.a
+
+		add_political_power = 100
+		hidden_effect = {
+			clr_country_flag = holiday_cabinet
+		}
 	}
 }
 

--- a/events/SCA_swedish_events.txt
+++ b/events/SCA_swedish_events.txt
@@ -113,7 +113,7 @@ country_event = {
 			}
 		}
 		else = {
-			add_popularity = { ideology = neutrality popularity = 25 }
+			add_popularity = { ideology = neutrality popularity = 0.25 }
 		}
 		set_politics = {
 			ruling_party = neutrality
@@ -317,7 +317,13 @@ country_event = {
 				}
 			}
 		}
-		SWE = { country_event = SCA_sweden.9 }
+		SWE = {
+			country_event = SCA_sweden.9
+			create_wargoal = {
+				type = annex_everything
+				target = ROOT
+			}
+		}
 	}
 }
 	country_event = {
@@ -2757,7 +2763,7 @@ country_event = {
 		give_guarantee = FROM
 		FROM = { 
 			give_military_access = ROOT
-			country_event = SCA_sweden.38
+			country_event = SCA_sweden.39
 		}
 	}
 	option = {
@@ -2773,7 +2779,7 @@ country_event = {
 				target = ROOT
 				modifier = SWE_refused_permit
 			}
-			country_event = SCA_sweden.39
+			country_event = SCA_sweden.40
 		}
 	}
 }

--- a/history/units/SWE_1936_naval_mtg.txt
+++ b/history/units/SWE_1936_naval_mtg.txt
@@ -15,7 +15,7 @@
 			
 			ship = { name = "HSwMS Magne" definition = destroyer equipment = { ship_hull_light_1 = { amount = 1 owner = SWE version_name = "Magne Class" } } }		
 			
-			ship = { name = "HSwMS Clas Fleming" definition = light_cruiser equipment = { ship_hull_cruiser_1 = { amount = 1 owner = SWE version_name = "Clas Fleming Class" } } }				
+			ship = { name = "HSwMS Clas Fleming" definition = heavy_cruiser equipment = { ship_hull_cruiser_1 = { amount = 1 owner = SWE version_name = "Clas Fleming Class" } } }				
 			
 			ship = { name = "HSwMS Sökaren" definition = SCA_gunboat equipment = { SCA_ship_hull_gunboat = { amount = 1 owner = SWE version_name = "Sökaren Class" } } }				
 			ship = { name = "HSwMS Sveparen" definition = SCA_gunboat equipment = { SCA_ship_hull_gunboat = { amount = 1 owner = SWE version_name = "Sökaren Class" } } }				
@@ -36,7 +36,7 @@
 			ship = { name = "HSwMS Sverige" definition = heavy_cruiser equipment = { ship_hull_cruiser_coastal_defense_ship = { amount = 1 owner = SWE version_name = "Sverige Class" } } }				
 			ship = { name = "HSwMS Drottning Victoria" definition = heavy_cruiser equipment = { ship_hull_cruiser_coastal_defense_ship = { amount = 1 owner = SWE version_name = "Sverige Class" } } }				
 			
-			ship = { name = "HSwMS Gotland" definition = light_cruiser equipment = { ship_hull_cruiser_2 = { amount = 1 owner = SWE version_name = "Gotland Class" } } }				
+			ship = { name = "HSwMS Gotland" definition = heavy_cruiser equipment = { ship_hull_cruiser_2 = { amount = 1 owner = SWE version_name = "Gotland Class" } } }				
 			# 1. Jagarflottiljen				
 			ship = { name = "HSwMS Klas Horn" definition = destroyer equipment = { ship_hull_light_1 = { amount = 1 owner = SWE version_name = "Klas Class" } } }		
 			ship = { name = "HSwMS Klas Uggla" definition = destroyer equipment = { ship_hull_light_1 = { amount = 1 owner = SWE version_name = "Klas Class" } } }		

--- a/history/units/SWE_1939_naval_mtg.txt
+++ b/history/units/SWE_1939_naval_mtg.txt
@@ -12,7 +12,7 @@
 			ship = { name = "HSwMS Örnen" definition = destroyer equipment = { ship_hull_light_1 = { amount = 1 owner = SWE version_name = "Örnen Class" } } }		
 			ship = { name = "HSwMS Jacob Bagge" definition = destroyer equipment = { ship_hull_light_1 = { amount = 1 owner = SWE version_name = "Örnen Class" } } }		
 			
-			ship = { name = "HSwMS Clas Fleming" definition = light_cruiser equipment = { ship_hull_cruiser_1 = { amount = 1 owner = SWE version_name = "Clas Fleming Class" } } }				
+			ship = { name = "HSwMS Clas Fleming" definition = heavy_cruiser equipment = { ship_hull_cruiser_1 = { amount = 1 owner = SWE version_name = "Clas Fleming Class" } } }				
 		
 			ship = { name = "HSwMS Sökaren" definition = SCA_gunboat equipment = { SCA_ship_hull_gunboat = { amount = 1 owner = SWE version_name = "Sökaren Class" } } }				
 			ship = { name = "HSwMS Sveparen" definition = SCA_gunboat equipment = { SCA_ship_hull_gunboat = { amount = 1 owner = SWE version_name = "Sökaren Class" } } }				
@@ -35,7 +35,7 @@
 			ship = { name = "HSwMS Sverige" definition = heavy_cruiser equipment = { ship_hull_cruiser_coastal_defense_ship = { amount = 1 owner = SWE version_name = "Sverige Class" } } }				
 			ship = { name = "HSwMS Drottning Victoria" definition = heavy_cruiser equipment = { ship_hull_cruiser_coastal_defense_ship = { amount = 1 owner = SWE version_name = "Sverige Class" } } }				
 			
-			ship = { name = "HSwMS Gotland" definition = light_cruiser equipment = { ship_hull_cruiser_2 = { amount = 1 owner = SWE version_name = "Gotland Class" } } }				
+			ship = { name = "HSwMS Gotland" definition = heavy_cruiser equipment = { ship_hull_cruiser_2 = { amount = 1 owner = SWE version_name = "Gotland Class" } } }				
 			# 1. Jagarflottiljen				
 			ship = { name = "HSwMS Klas Horn" definition = destroyer equipment = { ship_hull_light_1 = { amount = 1 owner = SWE version_name = "Klas Class" } } }		
 			ship = { name = "HSwMS Klas Uggla" definition = destroyer equipment = { ship_hull_light_1 = { amount = 1 owner = SWE version_name = "Klas Class" } } }		

--- a/localisation/sca_events_l_english.yml
+++ b/localisation/sca_events_l_english.yml
@@ -725,6 +725,11 @@
  SCA_sweden.2.a:0 "'Twas but a Holiday Cabinet"
  SCA_sweden.2.b:0 "Make whatever deals are necessary!"
  
+ SCA_sweden.41:0 "Minority Government Wins!"
+ SCA_sweden.41.t:0 "Minority Government Wins!"
+ SCA_sweden.41.desc:0 "Since forming a minority government this year, the non-socialist parties of Sweden have successfully created a large enough coalition to govern."
+ SCA_sweden.41.a:0 "'Tis but a Holiday Cabinet"
+ 
  SCA_sweden.3:0 "National Socialist Parties Merge"
  SCA_sweden.3.t:0 "National Socialist Parties Merge"
  SCA_sweden.3.desc:0 "There has been large National Socialist meeting in order to come to a merger agreement. All parties involved agree that the current situation is intolerable, too often they lose because they are simply too split to form a single front. However, the hard question remains, which party and which leader will become the united party's Riksledare, or "national leader"?"


### PR DESCRIPTION
 - Add claims to all Baltic states in 'Assert our claims over the Baltic'
 - Fix war goal creation over Baltic States if they agree to be your puppet
 - Fix a few issues caused by referencing characters with accented names
 - Fix ideas applied by 'Offensive Focus' and 'Defensive Focus'
 - Fix wrong events being triggered by 'Permittenttrafiken'
 - Fix neutrality popularity being increased by 2500% instead of 25%
 - Fix heavy cruisers being defined as light

Just fyi, Paradox advises referring to characters using their "character name" rather than their actual name which I assume is due to issues with character encoding accented names. I've fixed the ones for Martin Eugen Ekström I encountered and one for a Finnish character but I wanted to point out that this issue may exist elsewhere in your codebase as I didn't look for other occurrences.

Oh and I should note that these changes are compatible with Barbarossa v1.11.13